### PR TITLE
Four-quadrant pump curve

### DIFF
--- a/src/edge.rs
+++ b/src/edge.rs
@@ -90,22 +90,6 @@ impl Edge {
         }
     }
 
-    pub fn max_diameter(&mut self) -> &mut f64 {
-        match self {
-            Edge::Pipe(edge) => &mut edge.diameter,
-            Edge::Valve(edge) => &mut edge.diameter,
-            Edge::Pump(edge) => &mut edge.max_diameter,     // Impeller diameter
-        }
-    }
-
-    pub fn min_diameter(&mut self) -> &mut f64 {
-        match self {
-            Edge::Pipe(edge) => &mut edge.diameter,
-            Edge::Valve(edge) => &mut edge.diameter,
-            Edge::Pump(edge) => &mut edge.min_diameter,     // Impeller diameter
-        }
-    }
-
     pub fn area(&self) -> f64 {
         match self {
             Edge::Pipe(edge) => edge.area(),
@@ -155,7 +139,7 @@ impl Edge {
         }
     }
 
-    pub fn max_speed(&mut self) -> Option<&mut f64> {
+    /*pub fn max_speed(&mut self) -> Option<&mut f64> {
         match self {
             Edge::Pipe(_edge) => None,
             Edge::Valve(_edge) => None,
@@ -169,7 +153,7 @@ impl Edge {
             Edge::Valve(_edge) => None,
             Edge::Pump(edge) => Some(&mut edge.min_speed),
         }
-    }
+    }*/
 
     pub fn steady_open_percent(&mut self) -> &mut f64 {
         &mut self.open_percent().unwrap()[0]

--- a/src/edges/pipe.rs
+++ b/src/edges/pipe.rs
@@ -94,10 +94,4 @@ impl Pipe {
         result.sqrt()
     }
 
-    //TODO do we need this ???
-    /*pub fn create_transient_values(&mut self, tnodes: &[f64]) {
-        let mass_flow = vec![ self.mass_flow[0]; tnodes.len() ];
-        self.mass_flow = mass_flow;
-    } */
-
 }

--- a/src/edges/valve.rs
+++ b/src/edges/valve.rs
@@ -67,18 +67,7 @@ impl Valve {
             diameter: 52.5e-3,
             thickness: 0.005, // 5mm pipe
             youngs_modulus: 2.0e11, // Steel pipe TODO should be able to modify
-            k: vec![ 
-                (0.000, 1.0e16),
-                (0.111, 700.),
-                (0.222, 160.),
-                (0.333, 60.),
-                (0.444, 23.),
-                (0.556, 7.9),
-                (0.667, 3.),
-                (0.778, 1.4),
-                (0.889, 0.5),
-                (1.000, 0.25),
-            ],
+            k: default_valve_data(),
             open_percent: vec![ 1.0 ],
             events: vec![],
             width: 15.0, 
@@ -182,4 +171,19 @@ impl Valve {
         //self.mass_flow.push( *self.mass_flow.last().unwrap() );
     }
 
+}
+
+fn default_valve_data() -> Vec<(f64, f64)> {
+    vec![ 
+        (0.000, 1.0e16),
+        (0.111, 700.),
+        (0.222, 160.),
+        (0.333, 60.),
+        (0.444, 23.),
+        (0.556, 7.9),
+        (0.667, 3.),
+        (0.778, 1.4),
+        (0.889, 0.5),
+        (1.000, 0.25),
+    ]
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -82,7 +82,7 @@ impl TransientEvent {
     pub fn pump_speed(&self, time: f64, steady_speed: f64 ) -> f64 {
         match self {
             TransientEvent::None => steady_speed,
-            TransientEvent::InstantaneousChange(_,_) => steady_speed,
+            TransientEvent::InstantaneousChange(_,_) => steady_speed, //TODO: implement instantaneous change
             TransientEvent::ValveClosure(_,_,_) => steady_speed,
             TransientEvent::PumpLinearShutdown( event_time, shutdown_time) => {
                 if time < event_time.0 {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -292,8 +292,6 @@ impl Solver {
             iter += 1;
         }
         
-        
-
         if iter < self.max_iter && !max_residual.is_nan() {
             let t = *self.tnodes.last().unwrap();
             self.tnodes.push( t + dt );

--- a/tests/transient/events.rs
+++ b/tests/transient/events.rs
@@ -2,7 +2,7 @@ use eki::fluid::Fluid;
 use eki::node::Node;
 use eki::nodes::{ pressure::Pressure, connection::Connection };
 use eki::edge::Edge;
-use eki::edges::{ pipe::Pipe, valve::Valve };
+use eki::edges::{ pipe::Pipe, valve::Valve, pump::Pump };
 use eki::graph::Graph;
 use eki::solver::Solver;
 use eki::events::{TransientEvent, Time, Value};
@@ -86,7 +86,7 @@ fn valve_closure() {
     let mut solver = Solver::default();
     let mut network = Graph::new();
 
-    let mut node_from = Node::Pressure( Pressure::new_with_value( 0, 121325.0 ) );
+    let mut node_from = Node::Pressure( Pressure::new_with_value( 1, 121325.0 ) );
     assert_eq!( *node_from.pressure(), vec![ 121325.0 ] );
     network.add_node( node_from.clone() );
 
@@ -147,4 +147,95 @@ fn valve_closure() {
     assert!( mass_flow[2] < mass_flow[1] );
     assert!( mass_flow[2].abs() < 1.0e-3 )
 
+}
+
+#[test]
+fn pump_linear_shutdown() {
+    let fluid = Fluid::default();
+    let mut network = Graph::new();
+
+    let mut node_from = Node::Pressure( Pressure::new( 1 ) );
+    assert_eq!( *node_from.pressure(), vec![ 101325.0 ] );
+    network.add_node( node_from.clone() );
+
+    let node_to = Node::Pressure( Pressure::new_elevation( 2, 10.0 ) );
+    network.add_node( node_to.clone() );
+
+    let new_pump = Pump::new( node_from, node_to );
+    let mut pump = Edge::Pump( new_pump.clone() );
+    let event_time = Time( 0.0 );
+    let shutdown_time = Time( 10.0 );
+    let transient_event = TransientEvent::PumpLinearShutdown( event_time.clone(), shutdown_time.clone() );
+    pump.add_event( transient_event );
+    network.add_edge( pump );
+
+    let mut solver = Solver::default();
+    let result = solver.solve_steady( &mut network, &fluid, true );
+    if let Err(residual) = result {
+        println!( "residual = {}", residual );
+    } 
+    assert!( result.is_ok() && !result.is_err() );
+
+    let volume_flow = *network.edges()[0].steady_mass_flow() / fluid.density();
+    let q = volume_flow / new_pump.q_rated;
+    println!( "q = {}", q );
+    let n: f64 = 1.0; // Using the rated speed
+    let mut theta = n.atan2( q );
+    if theta < 0.0 { theta += 2.0 * std::f64::consts::PI; }
+    let fh = new_pump.f_h( theta );
+    let h = ( n * n + q * q ) * fh;
+    assert!( ( h - 10.0 / new_pump.h_rated ) < 1.0e-10 );
+    let steady_mass_flow = *network.edges()[0].steady_mass_flow();
+
+    let speed = network.edges()[0].speed().unwrap().clone();
+    assert_eq!( speed, vec![ 11300. ] );
+
+    let n = 50;
+
+    // A time step
+    *solver.dt() = 1.0 / (n as f64);
+    *solver.max_iter() = 50;
+    let result = solver.time_step( &mut network, &fluid );
+    match result {
+        Ok( iter ) => {
+            let speed = network.edges()[0].speed().unwrap().clone();
+            let mass_flow = network.edges()[0].mass_flow().clone();
+            println!( "iterations = {}, dt = {}, speed = {}, mass_flow = {}", iter, *solver.dt(), *speed.last().unwrap(), *mass_flow.last().unwrap() );
+            *solver.dt() *= if iter < 5 { 1.0 } else { 0.5 }; // Adaptive time-stepping
+        },
+        Err( residual ) => {
+            println!("Residual = {:+.2e}", residual );
+        }
+    } 
+
+    let speed = network.edges()[0].speed().unwrap().clone();
+    assert_eq!( speed, vec![ 11300., 11300. * ( 1.0 - ( ( *solver.dt() - event_time.0 ) / shutdown_time.0 ) ) ] );
+
+    let mass_flow = network.edges()[0].mass_flow().clone();
+    assert!( mass_flow[1] < steady_mass_flow );
+
+    let mut time = *solver.tnodes().last().unwrap();
+
+    // Some more time steps
+    while time < event_time.0 + shutdown_time.0 + 1.0 {
+        let result = solver.time_step( &mut network, &fluid );
+        match result {
+            Ok( iter ) => {
+                let speed = network.edges()[0].speed().unwrap().clone();
+                let mass_flow = network.edges()[0].mass_flow().clone();
+                println!( "iterations = {}, t = {}, speed = {}, mass_flow = {}", iter, time, *speed.last().unwrap(), *mass_flow.last().unwrap() );
+                *solver.dt() *= if iter < 5 { 1.1 } else { 0.5 }; // Adaptive time-stepping
+                time += *solver.dt();
+            },
+            Err( residual ) => {
+                println!("Residual = {:+.2e}", residual );
+                break;
+            }
+        }
+    }
+
+    let time = *solver.tnodes().last().unwrap();
+    println!( "time = {:?}", time );
+    let speed = network.edges()[0].speed().unwrap().clone();
+    assert_eq!( *speed.last().unwrap(), 0.0 ); 
 }


### PR DESCRIPTION
Redefined pumps to use four-quadrant data rather than coefficients. Further testing needs to be carried out and a way of creating the four-quadrant data from standard manufacturer data is required. 